### PR TITLE
Added Warning message

### DIFF
--- a/libexec/bootstrap
+++ b/libexec/bootstrap
@@ -4,5 +4,6 @@
 set -e
 
 if [ -f spec/fixtures/Puppetfile ]; then
+  echo 'WARNING: This may fail if it has been run to much. Wait a while and try again...'
   cd spec/fixtures && ../../.bundle/binstubs/librarian-puppet install
 fi


### PR DESCRIPTION
More of a discussion than an actual PR. Plus it means if people google the issue they'll see this page :smiley: 

Basically, if you run the bootstrap command too many times it will fail with this:

``` bash
Your bundle is complete!
It was installed into ./.bundle
Unable to find module 'boxen/puppet-boxen' on https://github.com
```

Or whichever module you've included in your puppetfile...

The biggest issue with this is Travis throwing false negatives, but I was able to replicate it by running it 10+ times on my local machine.

So, what do you think the best thing to do would be?
