### PR TITLE
Improve error message when no script name is given

### DIFF
--- a/bin/cardboard
+++ b/bin/cardboard
@@ -16,7 +16,7 @@ if ARGV.empty?
   abort "cardboard: No script given.\n#{usage}"
 end
 
-script  = libexec + ARGV.shift
+script = libexec + ARGV.shift
 
 unless script.executable?
   abort "cardboard: Unknown script: #{script}"

--- a/bin/cardboard
+++ b/bin/cardboard
@@ -4,6 +4,18 @@
 require "pathname"
 
 libexec = Pathname.new(__FILE__).realpath + "../../libexec"
+
+if ARGV.empty?
+  Dir.chdir(libexec)
+  entries = ''
+  Dir.glob('*').each { |entry|
+    entries += "   #{entry}\n"
+  }
+  usage = "usage: cardboard <script>\n\nAvailable scripts are:\n#{entries}"
+
+  abort "cardboard: No script given.\n#{usage}"
+end
+
 script  = libexec + ARGV.shift
 
 unless script.executable?


### PR DESCRIPTION
If no script name is given, cardboard will end up with a strange error as it will try to execute the parent directory:

```
../.bundle/ruby/2.1.0/gems/cardboard-1.0.4/bin/cardboard:13:in `exec': Permission denied - ../.bundle/ruby/2.1.0/gems/cardboard-1.0.4/libexec (Errno::EACCES)
	from ../.bundle/ruby/2.1.0/gems/cardboard-1.0.4/bin/cardboard:13:in `<top (required)>'
	from ../.bundle/ruby/2.1.0/bin/cardboard:23:in `load'
	from ../.bundle/ruby/2.1.0/bin/cardboard:23:in `<main>'
```

Proposed PR will print a simple usage with all available script names if no script name is given.
Example below.

```
cardboard: No script given.
usage: cardboard <script>

Available scripts are:
   bootstrap
   cibuild
   lint
   specs
   syntax
```