### PR TITLE
Make tests optinally verbose

### DIFF
--- a/libexec/specs
+++ b/libexec/specs
@@ -1,5 +1,11 @@
 #!/bin/sh
 # Run the Puppet RSpecs.
 
+if [ "$1" == "-v" ]; then
+  err_out=/dev/stderr
+else
+  err_out=/dev/null
+fi
+
 find spec -name '*_spec.rb' -not -path 'spec/fixtures/*' -print0 |
-  xargs -0 bundle exec rspec 2>/dev/null
+  xargs -0 bundle exec rspec 2>$err_out


### PR DESCRIPTION
It's currently a bit difficult to find out why am I getting e.g. deprecation warnings in tests as all details go directly to `/dev/null`. This PR is proposing option `-v` which will allow anyone to see what's actually happening if needed.